### PR TITLE
Adds a 'Force TCP' configuration option

### DIFF
--- a/valkka/live/chain/multifork.py
+++ b/valkka/live/chain/multifork.py
@@ -136,7 +136,8 @@ class MultiForkFilterchain(BaseFilterchain):
         # LiveThread specific
         "recv_buffer_size"  : (int, 0),     # Operating system socket ringbuffer size in bytes # 0 means default
         "reordering_mstime" : (int, 0),     # Reordering buffer time for Live555 packets in MILLIseconds # 0 means default
-    
+        "request_tcp" : (bool, False),
+
         # these are for the AVThread instance:
         "n_basic"      : (int, 20),  # number of payload frames in the stack
         "n_setup"      : (int, 20),  # number of setup frames in the stack
@@ -352,6 +353,9 @@ class MultiForkFilterchain(BaseFilterchain):
             self.ctx.connection_type = core.LiveConnectionType_rtsp
         else:
             self.ctx.connection_type = core.LiveConnectionType_sdp  # this is an rtsp connection
+
+        if (self.request_tcp):
+            self.ctx.request_tcp = self.request_tcp
 
         self.ctx.address = self.address
         # stream address, i.e. "rtsp://.."

--- a/valkka/live/datamodel/row.py
+++ b/valkka/live/datamodel/row.py
@@ -85,6 +85,11 @@ class RTSPCameraRow(Row):
             LineEditColumn, 
             key_name="tail", 
             label_name="Tail"),
+        ColumnSpec(
+            CheckBoxColumn,
+            key_name="force_tcp",
+            label_name="Force TCP",
+            def_value=False),
         
         ColumnSpec(
             LineEditColumn, 
@@ -164,6 +169,7 @@ class RTSPCameraRow(Row):
         self.placeWidget(cc, "password"); cc+=1
         self.placeWidget(cc, "port"); cc+=1
         self.placeWidget(cc, "tail"); cc+=1
+        self.placeWidget(cc, "force_tcp"); cc+=1
         # self.setVisible("tail", False) # test
         
         # Mainstream

--- a/valkka/live/device.py
+++ b/valkka/live/device.py
@@ -38,6 +38,8 @@ class RTSPCameraDevice:
         "password"  : str,
         "port"      : (str, ""),
         "tail"      : (str, ""),
+        "force_tcp" : (bool, False),
+
         "subaddress_main" : (str, ""),
         "live_main" : (bool, True),
         "rec_main"  : (bool, False),
@@ -71,6 +73,9 @@ class RTSPCameraDevice:
         if (len(self.subaddress_sub)>0):
             st += "/" + self.subaddress_main
         return st
+
+    def getForceTCP(self):
+        return self.force_tcp
 
     def getLabel(self):
         st = "rtsp://" + self.address
@@ -132,8 +137,6 @@ class USBCameraDevice:
     
     def getRecSlot(self):
         return (self.slot-1)*3+3
-
-
 
 
 class MyGui(QtWidgets.QMainWindow):

--- a/valkka/live/filterchain.py
+++ b/valkka/live/filterchain.py
@@ -168,6 +168,7 @@ class LiveFilterChainGroup(FilterChainGroup):
                             = self.gpu_handler.openglthreads,
                 address     = device.getMainAddress(),
                 slot        = device.getLiveMainSlot(),
+                request_tcp = device.getForceTCP(),
                 _id         = device._id,
                 affinity    = affinity,
                 msreconnect = 10000,


### PR DESCRIPTION
This is useful for streaming over the internet or over VPN connections. The configuration dictionary field is named 'force_tcp' and is passed to the `valkka-core` 'request_tcp' field.

If you can provide suggestions for the creation of unit tests, or a preferred factoring just let me know. I would be happy to improve this PR per guidance.